### PR TITLE
Log hyperparams to tensorboard with run IDs

### DIFF
--- a/configs/bert-large-uncased-pretraining.py
+++ b/configs/bert-large-uncased-pretraining.py
@@ -11,14 +11,16 @@ from colossalai.amp import AMP_TYPE
 
 from llm.models import bert as bert_models
 
+
 PHASE = 1
 SEED = 42
 BERT_CONFIG = bert_models.BERT_LARGE
 OPTIMIZER = 'lamb'
 GRADIENT_CHECKPOINTING = False
 OUTPUT_DIR = 'results/bert-large-pretraining'
-CHECKPOINT_DIR = os.path.join(OUTPUT_DIR, f'checkpoints/phase-{PHASE}')
-TENSORBOARD_DIR = os.path.join(OUTPUT_DIR, f'tensorboard/phase-{PHASE}')
+RUN_NAME = f'phase-{PHASE}'
+CHECKPOINT_DIR = os.path.join(OUTPUT_DIR, f'checkpoints/{RUN_NAME}')
+TENSORBOARD_DIR = os.path.join(OUTPUT_DIR, f'tensorboard/{RUN_NAME}')
 
 if PHASE == 1:
     MAX_SEQ_LENGTH = 128

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,8 +1,35 @@
 from __future__ import annotations
 
+import pathlib
+from typing import Any
+from unittest import mock
+
 import pytest
 
+from llm.utils import create_summary_writer
+from llm.utils import flatten_mapping
+from llm.utils import flattened_config
 from llm.utils import gradient_accumulation_steps
+
+
+def test_create_summary_writer(tmp_path: pathlib.Path) -> None:
+    writer = create_summary_writer(str(tmp_path))
+    writer.add_scalar('test', 0.1)
+    writer.close()
+
+    with pytest.raises(TypeError):
+        # missing_kwargs is passed to SummaryWriter which should error
+        create_summary_writer(str(tmp_path), missing_kwargs=True)
+
+
+def test_create_summary_writer_hparams(tmp_path: pathlib.Path) -> None:
+    writer = create_summary_writer(
+        str(tmp_path),
+        {'lr': 0.01, 'epochs': 0.1},
+        ['train/loss', 'train/lr'],
+    )
+    writer.add_scalar('train/loss', 0.1)
+    writer.close()
 
 
 def test_grad_accumulation_steps() -> None:
@@ -12,3 +39,48 @@ def test_grad_accumulation_steps() -> None:
 
     with pytest.raises(ValueError):
         gradient_accumulation_steps(8, 3, 2)
+
+
+def test_flattened_config() -> None:
+    with mock.patch('llm.utils.gpc') as mock_gpc:
+        mock_gpc.config = {}
+        assert flattened_config({'a': 1}) == {'a': 1}
+
+        mock_gpc.config = None
+        assert flattened_config({'a': 1}) == {'a': 1}
+
+        # gpc overrides caller base config
+        mock_gpc.config = {'a': 2}
+        assert flattened_config({'a': 1}) == {'a': 2}
+
+        # test get world size
+        mock_gpc.config = {}
+        with mock.patch(
+            'torch.distributed.is_initialized',
+            return_value=True,
+        ), mock.patch('torch.distributed.get_world_size', return_value=4):
+            assert flattened_config() == {'world_size': 4}
+
+        # test flattening and removing non-supported types
+        mock_gpc.config = {'a': {'b': 1, 'c': [1, 2]}}
+        assert flattened_config() == {'a_b': 1}
+
+
+@pytest.mark.parametrize(
+    'in_,out,kwargs',
+    (
+        ({}, {}, {}),
+        ({'a': 1}, {'a': 1}, {}),
+        ({'a': {'b': 1}}, {'a_b': 1}, {}),
+        ({'a': {'b': 1}}, {'a-b': 1}, {'sep': '-'}),
+        ({'a': {'b': 1}}, {'x_a_b': 1}, {'parent': 'x'}),
+        ({'a': {'b': {'c': 1}}}, {'a_b_c': 1}, {}),
+        ({'a': {'b': 1}, 'c': 2}, {'a_b': 1, 'c': 2}, {}),
+    ),
+)
+def test_flatten_mapping(
+    in_: dict[str, Any],
+    out: dict[str, Any],
+    kwargs: dict[str, Any],
+) -> None:
+    assert flatten_mapping(in_, **kwargs) == out


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Hyperparams are now associated with each run (where each run is unique to the `TENSORBOARD_DIR`). Users will need to change `TENSORBOARD_DIR` for each unique run/set of hyperparameters. If resuming from a checkpoint within the same run, the `TENSORBOARD_DIR` should stay the same.

The example config for BERT uses a `RUN_NAME` to specify distinct runs and allow for resuming a run by using the same `RUN_NAME`. Then, `tensorboard --logdir OUTPUT_DIR/tensorboard` will show all the runs in the "HPARAMS` tab with the full training config for each run. This should make comparing runs and hyperparameters way easier.

### Fixes N/A
<!--- List any issue numbers that this PR addresses (or remove) --->

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change for internal code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)

## Testing
<!--- Please describe the test ran to verify changes --->

Added unit tests and ran some small test runs to verify behavior for `llm.trainers.bert`.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
